### PR TITLE
Remove logger from notification controller

### DIFF
--- a/lib/instatus_api_consumer_web/controllers/webhooks/notification_controller.ex
+++ b/lib/instatus_api_consumer_web/controllers/webhooks/notification_controller.ex
@@ -1,15 +1,13 @@
 defmodule InstatusAPIConsumerWeb.Webhooks.NotificationController do
   use InstatusAPIConsumerWeb, :controller
 
-  require Logger
-
   action_fallback InstatusAPIConsumerWeb.FallbackController
 
   alias InstatusAPIConsumer.Incidents
 
   # Incident notification
   def notification(conn, %{"incident" => incident_params}) do
-    Logger.info("Incident notification: #{incident_params}")
+    IO.inspect("Incident notification: #{incident_params}")
     with {:ok, _} <- Incidents.create_or_update_incident(incident_params) do
       send_resp(conn, :no_content, "")
     end
@@ -17,15 +15,15 @@ defmodule InstatusAPIConsumerWeb.Webhooks.NotificationController do
 
   # Maintenance notification
   def notification(conn, %{"maintenance" => maintenance_params}) do
-    Logger.info("Maintenance notification: #{maintenance_params}")
+    IO.inspect("Maintenance notification: #{maintenance_params}")
 
     send_resp(conn, :no_content, "")
   end
 
   # Component notification
   def notification(conn, %{"component_update" => component_update_params, "component" => component_params}) do
-    Logger.info("Component update notification: #{component_update_params}")
-    Logger.info("Component notification: #{component_params}")
+    IO.inspect("Component update notification: #{component_update_params}")
+    IO.inspect("Component notification: #{component_params}")
 
     send_resp(conn, :no_content, "")
   end


### PR DESCRIPTION
### Why is this pull request necessary?
-The logger.info on notification controller isn't working properly

### What changes does this pull request add?
- Remove logger from notification controller