### PR TITLE
Revert "Remove logger from notification controller"

### DIFF
--- a/lib/instatus_api_consumer_web/controllers/webhooks/notification_controller.ex
+++ b/lib/instatus_api_consumer_web/controllers/webhooks/notification_controller.ex
@@ -1,13 +1,15 @@
 defmodule InstatusAPIConsumerWeb.Webhooks.NotificationController do
   use InstatusAPIConsumerWeb, :controller
 
+  require Logger
+
   action_fallback InstatusAPIConsumerWeb.FallbackController
 
   alias InstatusAPIConsumer.Incidents
 
   # Incident notification
   def notification(conn, %{"incident" => incident_params}) do
-    IO.inspect("Incident notification: #{incident_params}")
+    Logger.info("Incident notification: #{incident_params}")
     with {:ok, _} <- Incidents.create_or_update_incident(incident_params) do
       send_resp(conn, :no_content, "")
     end
@@ -15,15 +17,15 @@ defmodule InstatusAPIConsumerWeb.Webhooks.NotificationController do
 
   # Maintenance notification
   def notification(conn, %{"maintenance" => maintenance_params}) do
-    IO.inspect("Maintenance notification: #{maintenance_params}")
+    Logger.info("Maintenance notification: #{maintenance_params}")
 
     send_resp(conn, :no_content, "")
   end
 
   # Component notification
   def notification(conn, %{"component_update" => component_update_params, "component" => component_params}) do
-    IO.inspect("Component update notification: #{component_update_params}")
-    IO.inspect("Component notification: #{component_params}")
+    Logger.info("Component update notification: #{component_update_params}")
+    Logger.info("Component notification: #{component_params}")
 
     send_resp(conn, :no_content, "")
   end


### PR DESCRIPTION
The problem wasn't in the logger use, but on the string concatenation