### PR TITLE
Add create incidents worker

### DIFF
--- a/lib/instatus_api_consumer/incidents/create_incident_worker.ex
+++ b/lib/instatus_api_consumer/incidents/create_incident_worker.ex
@@ -1,0 +1,21 @@
+defmodule InstatusAPIConsumer.Incidents.CreateIncidentWorker do
+  use Oban.Worker, queue: :default
+
+  alias InstatusAPIConsumer.Incidents
+  alias InstatusAPIConsumer.Incidents.Incident
+
+  @spec enqueue(map()) :: {:ok, Oban.Job.t()} | {:error, Oban.Job.changeset() | term()}
+  def enqueue(%{} = args) do
+    args
+    |> new()
+    |> Oban.insert()
+  end
+
+  @impl Worker
+  def perform(%Job{args: args}) do
+    case Incidents.create_or_update_incident(args) do
+      {:ok, %Incident{} = incident} -> {:ok, incident}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+end

--- a/lib/instatus_api_consumer_web/controllers/webhooks/notification_controller.ex
+++ b/lib/instatus_api_consumer_web/controllers/webhooks/notification_controller.ex
@@ -5,16 +5,16 @@ defmodule InstatusAPIConsumerWeb.Webhooks.NotificationController do
 
   action_fallback InstatusAPIConsumerWeb.FallbackController
 
-  alias InstatusAPIConsumer.Incidents
+  alias InstatusAPIConsumer.Incidents.CreateIncidentWorker
 
   # Incident notification
   def notification(conn, %{"incident" => incident_params}) do
     Logger.info("Incident notification:")
     IO.inspect(incident_params)
 
-    with {:ok, _} <- Incidents.create_or_update_incident(incident_params) do
-      send_resp(conn, :no_content, "")
-    end
+    CreateIncidentWorker.enqueue(incident_params)
+
+    send_resp(conn, :no_content, "")
   end
 
   # Maintenance notification

--- a/test/instatus_api_consumer/incidents/create_incident_worker_test.exs
+++ b/test/instatus_api_consumer/incidents/create_incident_worker_test.exs
@@ -1,0 +1,38 @@
+defmodule InstatusAPIConsumer.Incidents.CreateIncidentWorkerTest do
+  use InstatusAPIConsumer.DataCase, async: true
+
+  alias InstatusAPIConsumer.Factory
+  alias InstatusAPIConsumer.Incidents.CreateIncidentWorker
+
+  describe "enqueue/1" do
+    test "inserts a new oban job" do
+      args = Factory.params_for(:incident)
+      assert {:ok, %Oban.Job{}} = CreateIncidentWorker.enqueue(args)
+
+      assert_enqueued(worker: CreateIncidentWorker, args: args, queue: :default)
+    end
+  end
+
+  describe "perform/2" do
+    test "creates a new incident" do
+      args = Factory.params_for(:incident)
+
+      assert {:ok, incident} = perform_job(CreateIncidentWorker, args)
+      assert incident.name == args.name
+      assert incident.impact == args.impact
+    end
+
+    test "returns error on incident creation" do
+      assert {:error, changeset} = perform_job(CreateIncidentWorker, %{})
+
+      assert errors_on(changeset) == %{
+               created_at: ["can't be blank"],
+               id: ["can't be blank"],
+               name: ["can't be blank"],
+               status: ["can't be blank"],
+               updated_at: ["can't be blank"],
+               url: ["can't be blank"]
+             }
+    end
+  end
+end

--- a/test/instatus_api_consumer_web/controllers/incidents/incident_controller_test.exs
+++ b/test/instatus_api_consumer_web/controllers/incidents/incident_controller_test.exs
@@ -5,7 +5,7 @@ defmodule InstatusAPIConsumerWeb.Incidents.IncidentControllerTest do
 
   describe "index/2" do
     test "returns 200 listing all incidents" do
-      incidents = Factory.insert_list(4, :incident, incident_updates: [])
+      incidents = Factory.insert_list(4, :incident)
       conn = get(build_conn(), "/api/incidents")
       body = json_response(conn, 200)
       assert body["data"] == build_index_body(incidents)

--- a/test/instatus_api_consumer_web/controllers/webhooks/notification_controller_test.exs
+++ b/test/instatus_api_consumer_web/controllers/webhooks/notification_controller_test.exs
@@ -1,15 +1,14 @@
 defmodule InstatusAPIConsumerWeb.Webhooks.NotificationControllerTest do
   use InstatusAPIConsumerWeb.ConnCase, async: true
 
-  alias InstatusAPIConsumer.Repo
+  alias InstatusAPIConsumer.Incidents.CreateIncidentWorker
   alias InstatusAPIConsumer.Factory
-  alias InstatusAPIConsumer.Incidents.Incident
 
   describe "notification/2" do
     test "returns 204 no content for incident notification" do
       payload = Factory.build(:incident_webhook_payload)
       conn = post(build_conn(), "/api/webhooks/notification", payload)
-      assert Repo.exists?(Incident, id: payload["incident"]["id"])
+      assert_enqueued(worker: CreateIncidentWorker, args: payload["incident"])
       assert response(conn, 204) == ""
     end
 


### PR DESCRIPTION
### Why is this pull request necessary?
- We want to create incidents on a background job so that the notification route doesn't brake if the creation breaks

### What changes does this pull request add?
- Add create incidents worker
- Update notification route to enqueue worker