### PR TITLE
Update auto stop machines to true

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -19,7 +19,7 @@ kill_signal = 'SIGTERM'
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = false
+  auto_stop_machines = true
   auto_start_machines = true
   min_machines_running = 0
   processes = ['app']


### PR DESCRIPTION
### Why is this pull request necessary?
- We want to stop the fly.io machines when the app is not used

### What changes does this pull request add?
- Update auto stop machines to true