### PR TITLE
Fix list incidents order by

### DIFF
--- a/lib/instatus_consumer/incidents.ex
+++ b/lib/instatus_consumer/incidents.ex
@@ -19,7 +19,7 @@ defmodule InstatusConsumer.Incidents do
 
   @spec list_incidents() :: list(Incident)
   def list_incidents do
-    query = from(i in Incident, order_by: i.created_at)
+    query = from(i in Incident, order_by: [desc: i.created_at])
     Repo.all(query)
   end
 end

--- a/test/instatus_consumer/incidents_test.exs
+++ b/test/instatus_consumer/incidents_test.exs
@@ -36,7 +36,7 @@ defmodule InstatusConsumer.IncidentsTest do
 
   describe "list_incidents/0" do
     test "retuns a list of incidents" do
-      incidents = Factory.insert_list(4, :incident)
+      incidents = Factory.insert_list(4, :incident) |> Enum.reverse()
       assert Incidents.list_incidents() == incidents
     end
   end

--- a/test/instatus_consumer_web/controllers/incidents/incident_controller_test.exs
+++ b/test/instatus_consumer_web/controllers/incidents/incident_controller_test.exs
@@ -5,7 +5,7 @@ defmodule InstatusConsumerWeb.Incidents.IncidentControllerTest do
 
   describe "index/2" do
     test "returns 200 listing all incidents" do
-      incidents = Factory.insert_list(4, :incident)
+      incidents = Factory.insert_list(4, :incident) |> Enum.reverse()
       conn = get(build_conn(), "/api/incidents")
       body = json_response(conn, 200)
       assert body["data"] == build_index_body(incidents)


### PR DESCRIPTION
### Why is this pull request necessary?
- We want to list the most current incident first on the list incidents endpoint

### What changes does this pull request add?
- Fix list incidents order by